### PR TITLE
Dropped PHP 8.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2
 
@@ -56,7 +56,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2
 
@@ -79,7 +79,7 @@ jobs:
       max-parallel: 3
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.3', '8.4']
         stability: [prefer-lowest, prefer-stable]
     name: Run tests on PHP ${{ matrix.php }} - ${{ matrix.stability }}
     steps:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A modern, fluent PHP package for managing robots.txt rules with type safety and 
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - Code coverage driver
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "source": "https://github.com/fkrzski/robots-txt"
     },
     "require": {
-        "php": "^8.2"
+        "php": "^8.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/rector.php
+++ b/rector.php
@@ -22,8 +22,8 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::DEAD_CODE,
         SetList::EARLY_RETURN,
         SetList::NAMING,
-        SetList::PHP_82,
+        SetList::PHP_83,
         SetList::TYPE_DECLARATION,
-        LevelSetList::UP_TO_PHP_82,
+        LevelSetList::UP_TO_PHP_83,
     ]);
 };

--- a/src/ValueObjects/CrawlDelay.php
+++ b/src/ValueObjects/CrawlDelay.php
@@ -24,24 +24,28 @@ final readonly class CrawlDelay implements ValueObject
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function value(): int
     {
         return $this->seconds;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function toString(): string
     {
         return (string) $this->seconds;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function equals(ValueObject $valueObject): bool
     {
         return $this->value() === $valueObject->value();
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function validate(): void
     {
         if ($this->seconds < 0) {

--- a/src/ValueObjects/Path.php
+++ b/src/ValueObjects/Path.php
@@ -28,24 +28,28 @@ final readonly class Path implements ValueObject
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function value(): string
     {
         return $this->path;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function toString(): string
     {
         return $this->path;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function equals(ValueObject $valueObject): bool
     {
         return $this->value() === $valueObject->value();
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function validate(): void
     {
         if ($this->path === '') {

--- a/src/ValueObjects/Rule.php
+++ b/src/ValueObjects/Rule.php
@@ -30,24 +30,28 @@ final readonly class Rule implements ValueObject
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function value(): string
     {
         return $this->toString();
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('%s: %s', $this->directiveEnum->value, $this->valueObject->toString());
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function equals(ValueObject $valueObject): bool
     {
         return $this->value() === $valueObject->value();
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function validate(): void
     {
         $this->valueObject->validate();

--- a/src/ValueObjects/Sitemap.php
+++ b/src/ValueObjects/Sitemap.php
@@ -27,24 +27,28 @@ final readonly class Sitemap implements ValueObject
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function value(): string
     {
         return $this->url;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function toString(): string
     {
         return $this->url;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function equals(ValueObject $valueObject): bool
     {
         return $this->value() === $valueObject->value();
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function validate(): void
     {
         if ($this->url === '') {

--- a/src/ValueObjects/UserAgent.php
+++ b/src/ValueObjects/UserAgent.php
@@ -23,24 +23,28 @@ final readonly class UserAgent implements ValueObject
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function value(): CrawlerEnum
     {
         return $this->crawlerEnum;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function toString(): string
     {
         return $this->crawlerEnum->value;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function equals(ValueObject $valueObject): bool
     {
         return $this->value() === $valueObject->value();
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function validate(): void
     {
         //


### PR DESCRIPTION
## Description

Dropped PHP 8.2 support, changed minimum version from PHP 8.2 to 8.3 in composer.json and Rector config file

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Checklist:

- [X] My code follows the code style of this project
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
- [X] I have updated the documentation accordingly
- [X] I have checked my code and corrected any misspellings
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] Type declarations are complete and accurate

## Additional Notes

