### PR TITLE
Add docs frontmatter validation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: Docs
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [
+      "master"
+    ]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  push:
+    branches: [
+      "master"
+    ]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    name: Validate docs frontmatter
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+
+    # Validates docs/ frontmatter, markdownlint rules and internal links against
+    # the shared contract. Pull the pin to @latest to always track the schema.
+    - name: Validate docs
+      run: npx --yes @fkrzski/docs-schema@0.1.0 docs


### PR DESCRIPTION
## Description

**What does this PR do?**

Adds a `Docs` GitHub Actions workflow (`.github/workflows/docs.yml`) that validates the `docs/` tree in CI using the shared `@fkrzski/docs-schema` contract. The check runs on pushes and pull requests to `master` that touch `docs/**` (or the workflow file itself), and can be triggered manually via `workflow_dispatch`. It sets up Node 24 and runs `npx @fkrzski/docs-schema docs`.

**Why is this change needed?**

The docs frontmatter (`title`, `description`, `repository`, `packagist`, `status`) is the single source that feeds the documentation site's schema, SEO/OG tags and status badge. This gates the repo so malformed frontmatter, markdownlint violations, or broken internal links fail fast in CI instead of surfacing downstream when the docs are synced.

**Any related issues?** —

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (non-breaking change that improves performance, readability, etc.)
- [ ] Documentation update

## Testing

- [ ] Test suite pass (`composer test`)
- [x] Manual testing with different URL scenarios completed

Validator run locally against `docs/` — passes (`✓ docs-validate`). No PHP/source changes, so the Composer test suite is unaffected.

## Backward Compatibility

- [x] No breaking changes to the public code
- [x] Changes do not introduce performance regressions

## Additional Notes

The validator is pinned to `@fkrzski/docs-schema@0.1.0` for reproducible CI; drop the pin to `@latest` to always track the schema. This workflow only adds a CI gate — no application or package code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)