### PR TITLE
docs: rewrite documentation as a multi-page set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p style="display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: center;">
-<img src="./art/banner.png" alt="Fkrzski PHP Package Skeleton"/>
+<img src="./art/banner.png" alt="PHP Robots.txt"/>
 <img alt="GitHub branch check runs" src="https://img.shields.io/github/check-runs/fkrzski/robots-txt/master?style=for-the-badge">
 <img alt="Packagist Downloads" src="https://img.shields.io/packagist/dt/fkrzski/robots-txt?style=for-the-badge">
 <img alt="Packagist Version" src="https://img.shields.io/packagist/v/fkrzski/robots-txt?style=for-the-badge">
@@ -27,7 +27,9 @@ composer require fkrzski/robots-txt
 
 ## Documentation
 
-The `RobotsTxt` class provides a fluent interface for creating and managing robots.txt rules with type safety and immutability.
+Full documentation is hosted at **[docs.fkrzski.dev/robots-txt](https://docs.fkrzski.dev/robots-txt)** — overview, guide, API reference, and the crawler list. The essentials are summarized below.
+
+The `RobotsTxt` class provides a fluent, chainable interface for creating robots.txt rules with type safety and fail-fast validation.
 
 ### Basic Methods
 
@@ -114,7 +116,7 @@ Sitemap: https://example.com/sitemap.xml
 
 A convenience method for quickly blocking access to the entire site. When `$disallow` is true (default):
 - Clears all existing rules in the current context (global or user-agent specific)
-- Adds a single "Disallow: /*" rule
+- Adds a single "Disallow: /" rule
 - Preserves sitemap entries and rules for other user agents
 
 ```php
@@ -123,13 +125,13 @@ $robots = new RobotsTxt();
 $robots
     ->allow('/public')    // This will be cleared
     ->disallow('/admin')  // This will be cleared
-    ->disallowAll();     // Only Disallow: /* remains
+    ->disallowAll();     // Only Disallow: / remains
 ```
 
 Output:
 ```
 User-agent: *
-Disallow: /*
+Disallow: /
 ```
 
 Block access only for specific crawler:
@@ -140,7 +142,7 @@ $robots
     ->userAgent(CrawlerEnum::GOOGLE)
     ->allow('/public')            // Google rule - cleared
     ->disallow('/private')        // Google rule - cleared
-    ->disallowAll()               // Only Disallow: /* for Google
+    ->disallowAll()               // Only Disallow: / for Google
     ->userAgent(CrawlerEnum::BING)
     ->disallow('/secret');        // Bing rule - keeps
 ```
@@ -151,7 +153,7 @@ User-agent: *
 Disallow: /admin
 
 User-agent: Googlebot
-Disallow: /*
+Disallow: /
 
 User-agent: Bingbot
 Disallow: /secret
@@ -424,7 +426,7 @@ We welcome contributions! Please see our [Contributing Guide](.github/CONTRIBUTI
 ### Quick Contribution Setup
 
 1. Fork this repository
-2. Clone your fork: `git clone https://github.com/yourusername/php-package-skeleton.git`
+2. Clone your fork: `git clone https://github.com/yourusername/robots-txt.git`
 3. Install dependencies: `composer install`
 4. Create a feature branch: `git checkout -b feature/amazing-feature`
 5. Make your changes and run tests: `composer test`
@@ -436,7 +438,7 @@ This project is open-sourced software licensed under the [MIT License](LICENSE.m
 
 ## 👨‍💻 Author
 
-**PHP Package Skeleton** was created by [Filip Krzyżanowski](https://linkedin.com/in/fkrzski).
+**PHP Robots.txt** was created by [Filip Krzyżanowski](https://linkedin.com/in/fkrzski).
 
 ## 🙏 Acknowledgments
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -244,24 +244,24 @@ be built. Bad paths, sitemaps, and crawl delays throw an
 
 Applies to `allow()` and `disallow()`. A path must:
 
-| Requirement                | Exception message                            |
-| -------------------------- | -------------------------------------------- |
-| Not be empty               | `Path cannot be empty`                       |
-| Start with `/`             | `Path must start with forward slash (/)`     |
-| No query string (`?`)      | `Path cannot contain query parameters`       |
-| No fragment (`#`)          | `Path cannot contain fragments`              |
-| No whitespace              | `Path cannot contain whitespace`             |
+| Requirement           | Exception message                        |
+| --------------------- | ---------------------------------------- |
+| Not be empty          | `Path cannot be empty`                   |
+| Start with `/`        | `Path must start with forward slash (/)` |
+| No query string (`?`) | `Path cannot contain query parameters`   |
+| No fragment (`#`)     | `Path cannot contain fragments`          |
+| No whitespace         | `Path cannot contain whitespace`         |
 
 ### Sitemap validation
 
 Applies to `sitemap()`. A URL must:
 
-| Requirement                | Exception message                            |
-| -------------------------- | -------------------------------------------- |
-| Not be empty               | `Sitemap URL cannot be empty`                |
-| Be a valid URL             | `Invalid sitemap URL format`                 |
-| Use `http` or `https`      | `Sitemap URL must use HTTP(S) protocol`      |
-| End with `.xml`            | `Sitemap URL must be in .xml format`         |
+| Requirement           | Exception message                       |
+| --------------------- | --------------------------------------- |
+| Not be empty          | `Sitemap URL cannot be empty`           |
+| Be a valid URL        | `Invalid sitemap URL format`            |
+| Use `http` or `https` | `Sitemap URL must use HTTP(S) protocol` |
+| End with `.xml`       | `Sitemap URL must be in .xml format`    |
 
 ### Crawl delay validation
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,277 @@
+---
+title: API reference
+description: Complete method reference for the RobotsTxt builder — signatures, validation rules, and verified output for every call.
+---
+
+Every public method of `RobotsTxt`, with its signature, behavior, and the exact
+output it produces. All methods return the builder for chaining, except `toFile()`
+(returns `bool`) and `toString()` (returns `string`).
+
+## allow()
+
+```text
+allow(string $path): self
+```
+
+Adds an `Allow` rule for `$path` to the current context.
+
+```php
+use Fkrzski\RobotsTxt\RobotsTxt;
+
+echo (new RobotsTxt())->allow('/public')->toString();
+```
+
+```text
+User-agent: *
+Allow: /public
+```
+
+## disallow()
+
+```text
+disallow(string $path): self
+```
+
+Adds a `Disallow` rule for `$path` to the current context. Same path rules as
+`allow()` (see [Path validation](#path-validation)).
+
+```php
+echo (new RobotsTxt())->disallow('/private')->toString();
+```
+
+```text
+User-agent: *
+Disallow: /private
+```
+
+## crawlDelay()
+
+```text
+crawlDelay(int $seconds): self
+```
+
+Adds a `Crawl-delay` rule to the current context. `$seconds` must be non-negative.
+
+```php
+echo (new RobotsTxt())->crawlDelay(10)->toString();
+```
+
+```text
+User-agent: *
+Crawl-delay: 10
+```
+
+## userAgent()
+
+```text
+userAgent(CrawlerEnum $crawler): self
+```
+
+Switches the current context to `$crawler`. Every rule added afterwards belongs to
+that crawler until the context changes. Referencing a crawler for the first time
+opens its block; referencing it again reuses the same block.
+
+```php
+use Fkrzski\RobotsTxt\Enums\CrawlerEnum;
+
+echo (new RobotsTxt())
+    ->userAgent(CrawlerEnum::GOOGLE)
+    ->disallow('/private')
+    ->allow('/public')
+    ->toString();
+```
+
+```text
+User-agent: Googlebot
+Disallow: /private
+Allow: /public
+```
+
+## forUserAgent()
+
+```text
+forUserAgent(CrawlerEnum $crawler, Closure(RobotsTxt): void $rules): self
+```
+
+Runs `$rules` with the context set to `$crawler`, then restores the previous
+context. Use it to group a crawler's rules without affecting later calls.
+
+```php
+$robots = new RobotsTxt();
+
+$robots->forUserAgent(CrawlerEnum::BING, function (RobotsTxt $robots): void {
+    $robots
+        ->disallow('/bing-private')
+        ->crawlDelay(10);
+});
+
+echo $robots->toString();
+```
+
+```text
+User-agent: Bingbot
+Disallow: /bing-private
+Crawl-delay: 10
+```
+
+## sitemap()
+
+```text
+sitemap(string $url): self
+```
+
+Adds a sitemap. Sitemaps are context-independent — they always render together in
+the trailing section, in insertion order (see [Sitemap validation](#sitemap-validation)).
+
+```php
+echo (new RobotsTxt())
+    ->sitemap('https://example.com/sitemap.xml')
+    ->toString();
+```
+
+```text
+Sitemap: https://example.com/sitemap.xml
+```
+
+## disallowAll()
+
+```text
+disallowAll(bool $disallow = true): self
+```
+
+Blocks the entire current context. When `$disallow` is `true` (the default) it
+**clears the existing rules of the current context** and adds a single
+`Disallow: /`. Global rules for other crawlers and all sitemaps are kept. When
+`$disallow` is `false` the method does nothing.
+
+Applied globally, it wipes the previously chained rules:
+
+```php
+echo (new RobotsTxt())
+    ->allow('/public')   // cleared
+    ->disallow('/admin') // cleared
+    ->disallowAll()
+    ->toString();
+```
+
+```text
+User-agent: *
+Disallow: /
+```
+
+Applied inside a crawler context, it only clears that crawler — global rules and
+other crawlers survive:
+
+```php
+echo (new RobotsTxt())
+    ->disallow('/admin')                  // global — kept
+    ->userAgent(CrawlerEnum::GOOGLE)
+    ->allow('/public')                    // Google — cleared
+    ->disallow('/private')                // Google — cleared
+    ->disallowAll()
+    ->userAgent(CrawlerEnum::BING)
+    ->disallow('/secret')                 // Bing — kept
+    ->toString();
+```
+
+```text
+User-agent: *
+Disallow: /admin
+
+User-agent: Googlebot
+Disallow: /
+
+User-agent: Bingbot
+Disallow: /secret
+```
+
+## toString()
+
+```text
+toString(): string
+```
+
+Renders the complete `robots.txt` content: global block, then each crawler block,
+then all sitemaps, separated by blank lines. Returns an empty string when no rules
+have been added.
+
+## toFile()
+
+```text
+toFile(?string $path = null): bool
+```
+
+Writes the rendered content to a file and returns `true` on success. With no
+argument it writes `robots.txt` to the current working directory.
+
+```php
+$robots = (new RobotsTxt())->disallow('/admin')->allow('/public');
+
+$robots->toFile();                           // ./robots.txt
+$robots->toFile('/var/www/html/robots.txt'); // custom path
+```
+
+Throws a `RuntimeException` when the target directory does not exist, or the
+directory or an existing file is not writable.
+
+## Wildcards
+
+Paths pass wildcard characters through unchanged, so the standard `*` (match any
+sequence) and `$` (match end of URL) patterns work as-is:
+
+```php
+echo (new RobotsTxt())
+    ->disallow('/*.php')     // block all PHP files
+    ->allow('/public/*')     // allow everything under /public
+    ->disallow('/private/$') // exact match for /private/
+    ->toString();
+```
+
+```text
+User-agent: *
+Disallow: /*.php
+Allow: /public/*
+Disallow: /private/$
+```
+
+## Validation
+
+Values are validated the moment you add them, so an invalid `robots.txt` can never
+be built. Bad paths, sitemaps, and crawl delays throw an
+`InvalidArgumentException`; file errors throw a `RuntimeException`.
+
+### Path validation
+
+Applies to `allow()` and `disallow()`. A path must:
+
+| Requirement                | Exception message                            |
+| -------------------------- | -------------------------------------------- |
+| Not be empty               | `Path cannot be empty`                       |
+| Start with `/`             | `Path must start with forward slash (/)`     |
+| No query string (`?`)      | `Path cannot contain query parameters`       |
+| No fragment (`#`)          | `Path cannot contain fragments`              |
+| No whitespace              | `Path cannot contain whitespace`             |
+
+### Sitemap validation
+
+Applies to `sitemap()`. A URL must:
+
+| Requirement                | Exception message                            |
+| -------------------------- | -------------------------------------------- |
+| Not be empty               | `Sitemap URL cannot be empty`                |
+| Be a valid URL             | `Invalid sitemap URL format`                 |
+| Use `http` or `https`      | `Sitemap URL must use HTTP(S) protocol`      |
+| End with `.xml`            | `Sitemap URL must be in .xml format`         |
+
+### Crawl delay validation
+
+Applies to `crawlDelay()`. The value must be non-negative, otherwise it throws
+`Crawl delay cannot be negative`.
+
+```php
+use Fkrzski\RobotsTxt\RobotsTxt;
+
+(new RobotsTxt())->disallow('admin');   // InvalidArgumentException: Path must start with forward slash (/)
+(new RobotsTxt())->sitemap('/site.xml'); // InvalidArgumentException: Sitemap URL must use HTTP(S) protocol
+(new RobotsTxt())->crawlDelay(-1);       // InvalidArgumentException: Crawl delay cannot be negative
+```

--- a/docs/crawlers.md
+++ b/docs/crawlers.md
@@ -28,40 +28,40 @@ The rendered `User-agent:` line is the enum's backing value, listed below.
 
 ### Google
 
-| Case                        | User-agent            |
-| --------------------------- | --------------------- |
-| `CrawlerEnum::GOOGLE`        | `Googlebot`           |
-| `CrawlerEnum::GOOGLE_IMAGES` | `Googlebot-Image`     |
-| `CrawlerEnum::GOOGLE_NEWS`   | `Googlebot-News`      |
-| `CrawlerEnum::GOOGLE_VIDEO`  | `Googlebot-Video`     |
-| `CrawlerEnum::GOOGLE_ADS`    | `AdsBot-Google`       |
-| `CrawlerEnum::GOOGLE_ADSENSE`| `Mediapartners-Google`|
+| Case                          | User-agent             |
+| ----------------------------- | ---------------------- |
+| `CrawlerEnum::GOOGLE`         | `Googlebot`            |
+| `CrawlerEnum::GOOGLE_IMAGES`  | `Googlebot-Image`      |
+| `CrawlerEnum::GOOGLE_NEWS`    | `Googlebot-News`       |
+| `CrawlerEnum::GOOGLE_VIDEO`   | `Googlebot-Video`      |
+| `CrawlerEnum::GOOGLE_ADS`     | `AdsBot-Google`        |
+| `CrawlerEnum::GOOGLE_ADSENSE` | `Mediapartners-Google` |
 
 ### Bing
 
-| Case                       | User-agent    |
-| -------------------------- | ------------- |
-| `CrawlerEnum::BING`         | `Bingbot`     |
-| `CrawlerEnum::BING_PREVIEW` | `BingPreview` |
-| `CrawlerEnum::MSN`          | `msnbot`      |
-| `CrawlerEnum::MSN_MEDIA`    | `msnbot-media`|
+| Case                        | User-agent     |
+| --------------------------- | -------------- |
+| `CrawlerEnum::BING`         | `Bingbot`      |
+| `CrawlerEnum::BING_PREVIEW` | `BingPreview`  |
+| `CrawlerEnum::MSN`          | `msnbot`       |
+| `CrawlerEnum::MSN_MEDIA`    | `msnbot-media` |
 
 ### Other engines
 
-| Case                          | User-agent         |
-| ----------------------------- | ------------------ |
-| `CrawlerEnum::YAHOO`           | `Slurp`            |
-| `CrawlerEnum::DUCKDUCKGO`      | `DuckDuckBot`      |
-| `CrawlerEnum::YANDEX`          | `YandexBot`        |
-| `CrawlerEnum::BAIDU`           | `Baiduspider`      |
-| `CrawlerEnum::NAVER`           | `Naverbot`         |
-| `CrawlerEnum::SOGOU_WEB_SPIDER`| `Sogou web spider` |
-| `CrawlerEnum::QWANT`           | `Qwantify`         |
+| Case                            | User-agent         |
+| ------------------------------- | ------------------ |
+| `CrawlerEnum::YAHOO`            | `Slurp`            |
+| `CrawlerEnum::DUCKDUCKGO`       | `DuckDuckBot`      |
+| `CrawlerEnum::YANDEX`           | `YandexBot`        |
+| `CrawlerEnum::BAIDU`            | `Baiduspider`      |
+| `CrawlerEnum::NAVER`            | `Naverbot`         |
+| `CrawlerEnum::SOGOU_WEB_SPIDER` | `Sogou web spider` |
+| `CrawlerEnum::QWANT`            | `Qwantify`         |
 
 ## Social media
 
-| Case                    | User-agent            |
-| ----------------------- | --------------------- |
+| Case                     | User-agent            |
+| ------------------------ | --------------------- |
 | `CrawlerEnum::FACEBOOK`  | `facebookexternalhit` |
 | `CrawlerEnum::TWITTER`   | `Twitterbot`          |
 | `CrawlerEnum::LINKEDIN`  | `LinkedInBot`         |
@@ -74,20 +74,20 @@ The rendered `User-agent:` line is the enum's backing value, listed below.
 
 | Case                  | User-agent  |
 | --------------------- | ----------- |
-| `CrawlerEnum::AMAZON`  | `Amazonbot` |
+| `CrawlerEnum::AMAZON` | `Amazonbot` |
 
 ## Archives
 
-| Case                          | User-agent                     |
-| ----------------------------- | ------------------------------ |
-| `CrawlerEnum::INTERNET_ARCHIVE`| `ia_archiver`                  |
-| `CrawlerEnum::ALEXA`           | `ia_archiver-web.archive.org`  |
-| `CrawlerEnum::ARCHIVE_ORG`     | `archive.org_bot`              |
+| Case                            | User-agent                    |
+| ------------------------------- | ----------------------------- |
+| `CrawlerEnum::INTERNET_ARCHIVE` | `ia_archiver`                 |
+| `CrawlerEnum::ALEXA`            | `ia_archiver-web.archive.org` |
+| `CrawlerEnum::ARCHIVE_ORG`      | `archive.org_bot`             |
 
 ## SEO tools
 
-| Case                         | User-agent                  |
-| ---------------------------- | --------------------------- |
+| Case                          | User-agent                  |
+| ----------------------------- | --------------------------- |
 | `CrawlerEnum::AHREFS`         | `AhrefsBot`                 |
 | `CrawlerEnum::SEMRUSH`        | `SemrushBot`                |
 | `CrawlerEnum::MAJESTIC`       | `MJ12bot`                   |
@@ -96,9 +96,9 @@ The rendered `User-agent:` line is the enum's backing value, listed below.
 
 ## Feed readers & validators
 
-| Case                       | User-agent          |
-| -------------------------- | ------------------- |
-| `CrawlerEnum::FEEDLY`       | `Feedly`            |
-| `CrawlerEnum::W3C_VALIDATOR`| `W3C-checklink`     |
-| `CrawlerEnum::CSS_VALIDATOR`| `W3C_CSS_Validator` |
-| `CrawlerEnum::HTML_VALIDATOR`| `W3C_Validator`    |
+| Case                          | User-agent          |
+| ----------------------------- | ------------------- |
+| `CrawlerEnum::FEEDLY`         | `Feedly`            |
+| `CrawlerEnum::W3C_VALIDATOR`  | `W3C-checklink`     |
+| `CrawlerEnum::CSS_VALIDATOR`  | `W3C_CSS_Validator` |
+| `CrawlerEnum::HTML_VALIDATOR` | `W3C_Validator`     |

--- a/docs/crawlers.md
+++ b/docs/crawlers.md
@@ -1,0 +1,104 @@
+---
+title: Crawlers
+description: Every crawler in CrawlerEnum mapped to its official user-agent string, grouped by search engines, social platforms, SEO tools, and more.
+---
+
+`CrawlerEnum` maps each supported crawler to its official user-agent string. Pass a
+case to `userAgent()` or `forUserAgent()` instead of typing the string by hand — a
+typo becomes a compile-time error rather than a silently ignored rule.
+
+```php
+use Fkrzski\RobotsTxt\RobotsTxt;
+use Fkrzski\RobotsTxt\Enums\CrawlerEnum;
+
+echo (new RobotsTxt())
+    ->userAgent(CrawlerEnum::GOOGLE)
+    ->disallow('/private')
+    ->toString();
+```
+
+```text
+User-agent: Googlebot
+Disallow: /private
+```
+
+The rendered `User-agent:` line is the enum's backing value, listed below.
+
+## Search engines
+
+### Google
+
+| Case                        | User-agent            |
+| --------------------------- | --------------------- |
+| `CrawlerEnum::GOOGLE`        | `Googlebot`           |
+| `CrawlerEnum::GOOGLE_IMAGES` | `Googlebot-Image`     |
+| `CrawlerEnum::GOOGLE_NEWS`   | `Googlebot-News`      |
+| `CrawlerEnum::GOOGLE_VIDEO`  | `Googlebot-Video`     |
+| `CrawlerEnum::GOOGLE_ADS`    | `AdsBot-Google`       |
+| `CrawlerEnum::GOOGLE_ADSENSE`| `Mediapartners-Google`|
+
+### Bing
+
+| Case                       | User-agent    |
+| -------------------------- | ------------- |
+| `CrawlerEnum::BING`         | `Bingbot`     |
+| `CrawlerEnum::BING_PREVIEW` | `BingPreview` |
+| `CrawlerEnum::MSN`          | `msnbot`      |
+| `CrawlerEnum::MSN_MEDIA`    | `msnbot-media`|
+
+### Other engines
+
+| Case                          | User-agent         |
+| ----------------------------- | ------------------ |
+| `CrawlerEnum::YAHOO`           | `Slurp`            |
+| `CrawlerEnum::DUCKDUCKGO`      | `DuckDuckBot`      |
+| `CrawlerEnum::YANDEX`          | `YandexBot`        |
+| `CrawlerEnum::BAIDU`           | `Baiduspider`      |
+| `CrawlerEnum::NAVER`           | `Naverbot`         |
+| `CrawlerEnum::SOGOU_WEB_SPIDER`| `Sogou web spider` |
+| `CrawlerEnum::QWANT`           | `Qwantify`         |
+
+## Social media
+
+| Case                    | User-agent            |
+| ----------------------- | --------------------- |
+| `CrawlerEnum::FACEBOOK`  | `facebookexternalhit` |
+| `CrawlerEnum::TWITTER`   | `Twitterbot`          |
+| `CrawlerEnum::LINKEDIN`  | `LinkedInBot`         |
+| `CrawlerEnum::PINTEREST` | `Pinterest`           |
+| `CrawlerEnum::DISCORD`   | `Discordbot`          |
+| `CrawlerEnum::SLACK`     | `Slackbot`            |
+| `CrawlerEnum::WHATSAPP`  | `WhatsApp`            |
+
+## E-commerce
+
+| Case                  | User-agent  |
+| --------------------- | ----------- |
+| `CrawlerEnum::AMAZON`  | `Amazonbot` |
+
+## Archives
+
+| Case                          | User-agent                     |
+| ----------------------------- | ------------------------------ |
+| `CrawlerEnum::INTERNET_ARCHIVE`| `ia_archiver`                  |
+| `CrawlerEnum::ALEXA`           | `ia_archiver-web.archive.org`  |
+| `CrawlerEnum::ARCHIVE_ORG`     | `archive.org_bot`              |
+
+## SEO tools
+
+| Case                         | User-agent                  |
+| ---------------------------- | --------------------------- |
+| `CrawlerEnum::AHREFS`         | `AhrefsBot`                 |
+| `CrawlerEnum::SEMRUSH`        | `SemrushBot`                |
+| `CrawlerEnum::MAJESTIC`       | `MJ12bot`                   |
+| `CrawlerEnum::MOZ`            | `rogerbot`                  |
+| `CrawlerEnum::SCREAMING_FROG` | `Screaming Frog SEO Spider` |
+
+## Feed readers & validators
+
+| Case                       | User-agent          |
+| -------------------------- | ------------------- |
+| `CrawlerEnum::FEEDLY`       | `Feedly`            |
+| `CrawlerEnum::W3C_VALIDATOR`| `W3C-checklink`     |
+| `CrawlerEnum::CSS_VALIDATOR`| `W3C_CSS_Validator` |
+| `CrawlerEnum::HTML_VALIDATOR`| `W3C_Validator`    |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,152 @@
+---
+title: Guide
+description: How the RobotsTxt builder composes global and crawler-specific rules, orders its output, and writes robots.txt files to disk.
+---
+
+This guide covers the mental model behind the builder: how rules are grouped, how
+the final file is ordered, and how to persist it.
+
+## Global vs crawler context
+
+The builder tracks a *current context*. Until you call `userAgent()`, every rule
+you add is **global** and renders under `User-agent: *`:
+
+```php
+use Fkrzski\RobotsTxt\RobotsTxt;
+
+$robots = new RobotsTxt();
+
+echo $robots
+    ->disallow('/admin')
+    ->allow('/public')
+    ->toString();
+```
+
+```text
+User-agent: *
+Disallow: /admin
+Allow: /public
+```
+
+Calling `userAgent()` switches the context: every rule after it belongs to that
+crawler until you switch again.
+
+```php
+use Fkrzski\RobotsTxt\Enums\CrawlerEnum;
+
+echo $robots
+    ->disallow('/admin')              // global
+    ->userAgent(CrawlerEnum::GOOGLE)
+    ->disallow('/google-only')        // Googlebot
+    ->userAgent(CrawlerEnum::BING)
+    ->disallow('/bing-only')          // Bingbot
+    ->toString();
+```
+
+```text
+User-agent: *
+Disallow: /admin
+
+User-agent: Googlebot
+Disallow: /google-only
+
+User-agent: Bingbot
+Disallow: /bing-only
+```
+
+## userAgent() vs forUserAgent()
+
+`userAgent()` sets the context and leaves it set — every following rule sticks to
+that crawler. `forUserAgent()` scopes a group of rules to a crawler inside a
+closure, then restores the previous context when the closure returns. Use it when
+you want a self-contained block without leaking the context into later calls:
+
+```php
+$robots
+    ->disallow('/admin')                    // global
+    ->forUserAgent(CrawlerEnum::GOOGLE, function (RobotsTxt $robots): void {
+        $robots
+            ->disallow('/private')
+            ->crawlDelay(10);
+    })
+    ->allow('/public');                     // still global — context restored
+```
+
+```text
+User-agent: *
+Disallow: /admin
+Allow: /public
+
+User-agent: Googlebot
+Disallow: /private
+Crawl-delay: 10
+```
+
+Note how `allow('/public')` lands back in the global block even though it comes
+after the Google group in the source.
+
+## Output ordering
+
+`toString()` always emits sections in a fixed order, regardless of the order you
+called the methods:
+
+1. Global rules (under `User-agent: *`), if any
+2. Each crawler block, in the order its crawler was first referenced
+3. All sitemaps, last
+
+Blocks are separated by a blank line. A realistic example combining all three:
+
+```php
+$robots = new RobotsTxt();
+
+echo $robots
+    ->disallow('/admin')
+    ->sitemap('https://example.com/sitemap1.xml')
+    ->forUserAgent(CrawlerEnum::GOOGLE, function (RobotsTxt $robots): void {
+        $robots
+            ->disallow('/google-private')
+            ->allow('/public/*');
+    })
+    ->forUserAgent(CrawlerEnum::BING, function (RobotsTxt $robots): void {
+        $robots
+            ->disallow('/bing-private')
+            ->crawlDelay(5);
+    })
+    ->sitemap('https://example.com/sitemap2.xml')
+    ->toString();
+```
+
+```text
+User-agent: *
+Disallow: /admin
+
+User-agent: Googlebot
+Disallow: /google-private
+Allow: /public/*
+
+User-agent: Bingbot
+Disallow: /bing-private
+Crawl-delay: 5
+
+Sitemap: https://example.com/sitemap1.xml
+Sitemap: https://example.com/sitemap2.xml
+```
+
+The two sitemaps were added at opposite ends of the chain, yet both render
+together in the trailing sitemap section, in insertion order.
+
+## Writing to disk
+
+`toFile()` renders the content and writes it to a file. With no argument it writes
+`robots.txt` to the current working directory:
+
+```php
+$robots->toFile();                           // ./robots.txt
+$robots->toFile('/var/www/html/robots.txt'); // custom path
+```
+
+It returns `true` on success and throws a `RuntimeException` when the target
+directory does not exist, or the directory or an existing file is not writable.
+
+See the [API reference](./api-reference.md) for the per-method details and the
+full validation rules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,26 +1,25 @@
 ---
 title: robots-txt
-description: A modern, fluent PHP package for building type-safe, immutable robots.txt rules with a first-class developer experience.
+description: A modern, fluent PHP package for building valid robots.txt files with type-safe crawlers and fail-fast validation.
 repository: https://github.com/fkrzski/robots-txt
 packagist: fkrzski/robots-txt
 status: stable
 ---
 
-A modern, fluent PHP package for building `robots.txt` files with **type safety**
-and **immutability**. The `RobotsTxt` class exposes a chainable interface that
-guides you toward valid output — invalid paths, sitemaps, or crawl delays fail
-fast with clear exceptions instead of shipping a broken file.
+A modern, fluent PHP package for building `robots.txt` files. The `RobotsTxt`
+class exposes a chainable interface that guides you toward valid output — invalid
+paths, sitemap URLs, or crawl delays fail fast with a clear exception instead of
+shipping a broken file.
 
 ## Why robots-txt
 
-- **Fluent & chainable** — every rule method returns a new instance, so building
-  a policy reads top to bottom.
+- **Fluent & chainable** — every method returns the builder, so a policy reads
+  top to bottom.
 - **Type-safe crawlers** — target bots through the `CrawlerEnum` instead of
   hand-writing user-agent strings.
 - **Validated by design** — paths, sitemap URLs, and crawl delays are checked as
   you build, never at render time.
-- **Immutable** — nothing mutates in place, making rule sets safe to compose and
-  reuse.
+- **Zero runtime dependencies** — one small package, nothing to pull in.
 
 ## Requirements
 
@@ -37,7 +36,7 @@ composer require fkrzski/robots-txt
 
 ## Quick start
 
-Chain rules fluently and render the result with `toString()`:
+Chain rules and render the result with `toString()`:
 
 ```php
 use Fkrzski\RobotsTxt\RobotsTxt;
@@ -58,90 +57,14 @@ Allow: /public
 Crawl-delay: 5
 ```
 
-## Targeting specific crawlers
+Rules added before any `userAgent()` call apply to every crawler and render under
+`User-agent: *`.
 
-Use the `CrawlerEnum` to scope rules to a single bot — the enum maps each case to
-its official user-agent string, so you never memorize `Googlebot` or `Bingbot`.
+## Where to next
 
-```php
-use Fkrzski\RobotsTxt\RobotsTxt;
-use Fkrzski\RobotsTxt\Enums\CrawlerEnum;
-
-$robots = new RobotsTxt();
-
-echo $robots
-    ->userAgent(CrawlerEnum::GOOGLE)
-    ->disallow('/private')
-    ->allow('/public')
-    ->toString();
-```
-
-```text
-User-agent: Googlebot
-Disallow: /private
-Allow: /public
-```
-
-For grouped, self-contained crawler rules, reach for the closure-based
-`forUserAgent()`:
-
-```php
-$robots->forUserAgent(CrawlerEnum::BING, function (RobotsTxt $robots): void {
-    $robots
-        ->disallow('/bing-private')
-        ->crawlDelay(10);
-});
-```
-
-## Sitemaps and full blocks
-
-Add sitemaps and block an entire site with dedicated helpers:
-
-```php
-use Fkrzski\RobotsTxt\RobotsTxt;
-
-$robots = new RobotsTxt();
-
-echo $robots
-    ->sitemap('https://example.com/sitemap.xml')
-    ->disallowAll()
-    ->toString();
-```
-
-```text
-User-agent: *
-Disallow: /*
-
-Sitemap: https://example.com/sitemap.xml
-```
-
-## Writing to disk
-
-Persist the output straight to a file with `toFile()`. Called with no argument it
-writes `robots.txt` to the project root:
-
-```php
-$robots->toFile();                          // ./robots.txt
-$robots->toFile('/var/www/html/robots.txt'); // custom path
-```
-
-It returns `true` on success and throws a `RuntimeException` when the target
-directory or existing file is not writable.
-
-## Validation rules
-
-Building fails fast with an `InvalidArgumentException` when a value would produce
-an invalid `robots.txt`:
-
-| Input       | Requirement                                        |
-| ----------- | -------------------------------------------------- |
-| Path        | Starts with `/`, no query string or fragment       |
-| Sitemap URL | Valid HTTP/HTTPS URL ending in `.xml`              |
-| Crawl delay | Non-negative integer                               |
-
-## Next steps
-
-- Browse the full API and advanced examples in the
-  [README](https://github.com/fkrzski/robots-txt#readme).
-- Report issues or request features on the
-  [issue tracker](https://github.com/fkrzski/robots-txt/issues).
+- **[Guide](./guide.md)** — how global and crawler-specific rules compose, how the
+  output is ordered, and how to write the file to disk.
+- **[API reference](./api-reference.md)** — every method with its signature,
+  validation rules, and verified output.
+- **[Crawlers](./crawlers.md)** — the full `CrawlerEnum` list mapped to official
+  user-agent strings.


### PR DESCRIPTION
Rewrites the project documentation as a four-page set for the Starlight docs site ([docs.fkrzski.dev/robots-txt](https://docs.fkrzski.dev/robots-txt)) and brings the README in line with it. Every code example's output was verified against the source on PHP 8.4.

## Docs (`docs/`)

| Page | Content |
| --- | --- |
| `index.md` | Overview, why, requirements, installation, quick start |
| `guide.md` | Global vs crawler context, `userAgent()` vs `forUserAgent()`, output ordering, `toFile()` |
| `api-reference.md` | Per-method reference (signature + verified output), wildcards, validation tables with exact exception messages |
| `crawlers.md` | Full `CrawlerEnum` list mapped to official user-agent strings, grouped |

## Correctness fixes (were wrong in both docs and README)

- `disallowAll()` renders `Disallow: /`, **not** `Disallow: /*`.
- Dropped the **"immutable"** claim — the builder is fluent/chainable but mutates in place and returns the same instance.

## README

- Links to the hosted documentation and aligns summary content with the new pages.
- Fixed the `disallowAll()` output in both examples.
- Removed leftover "PHP Package Skeleton" references (banner alt, author, clone URL).

## Notes

- The docs sidebar is registered in the separate `fkrzski.dev` repo (`apps/docs/src/data/projects.ts`); the matching `items[]` entries for Guide / API reference / Crawlers are **not** part of this PR and need a change there for the new pages to appear in navigation.
- Validated locally against what the `@fkrzski/docs-schema` contract enforces (description length 50–160, tagged code fences, relative links resolve). The official `npx @fkrzski/docs-schema docs` check and a Starlight build were not run here (no Node in the environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)